### PR TITLE
Release version in setup.py commandline should not break setup.py

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: setup
         run: pip install wheel
       - name: build
-        run: python setup.py ${GITHUB_REF#refs/tags/v} sdist bdist_wheel
+        run: python setup.py --release-version ${GITHUB_REF#refs/tags/v} sdist bdist_wheel
       - name: release
         uses: pypa/gh-action-pypi-publish@master
         with:

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,11 @@ from setuptools import find_packages, setup
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
-VERSION = sys.argv.pop(1)
-assert re.match(r"[0-9]+\.[0-9]+\.[0-9]+", VERSION), "Version definition required as first arg"
+VERSION = "devel"
+if sys.argv[1] == "--release-version":
+    sys.argv.pop(1)
+    VERSION = sys.argv.pop(1)
+    assert re.match(r"[0-9]+\.[0-9]+\.[0-9]+", VERSION), "Version definition required as first arg"
 
 requirements = ['requests']
 


### PR DESCRIPTION
As implemented intially it made impossible/hard to install library
directly from codebase. Here is an attempt to make it possible again.