### PR TITLE
Limit backoff on wait_for_tenant just for 404 errors.

### DIFF
--- a/threescale_api/client.py
+++ b/threescale_api/client.py
@@ -68,13 +68,18 @@ class ThreeScaleClient:
         # ultimate readiness check. There might be duplicates though, so
         # worth to review it one day
         try:
-            return self.account_plans.exists() \
+            return self.account_plans.exists(throws=True) \
                 and len(self.account_plans.fetch()["plans"]) >= 1 \
                 and len(self.account_plans.list()) >= 1 \
-                and self.accounts.exists() \
+                and self.accounts.exists(throws=True) \
                 and len(self.accounts.list()) >= 1 \
-                and self.services.exists() \
+                and self.services.exists(throws=True) \
                 and len(self.services.list()) >= 1
+        except errors.ApiClientError as err:
+            if err.code in (404, 503):
+                log.info("wait_for_tenant failed: %s", err)
+                return False
+            raise err
         except Exception as err:
             log.info("wait_for_tenant failed: %s", err)
             return False

--- a/threescale_api/defaults.py
+++ b/threescale_api/defaults.py
@@ -91,7 +91,7 @@ class DefaultClient(collections.abc.Mapping):
         response = self.rest.delete(url=url, **kwargs)
         return response.ok
 
-    def exists(self, entity_id=None, **kwargs) -> bool:
+    def exists(self, entity_id=None, throws=False, **kwargs) -> bool:
         """Check whether the resource exists
         Args:
             entity_id(int): Entity id
@@ -101,7 +101,7 @@ class DefaultClient(collections.abc.Mapping):
         """
         log.info(self._log_message("[EXIST] Resource exist ", entity_id=entity_id, args=kwargs))
         url = self._entity_url(entity_id=entity_id)
-        response = self.rest.get(url=url, throws=False, **kwargs)
+        response = self.rest.get(url=url, throws=throws, **kwargs)
         return response.ok
 
     def update(self, entity_id=None, params: dict = None, **kwargs) -> 'DefaultResource':


### PR DESCRIPTION
Error 404 is the only error that can occur due to incomplete
initialization in 3scale, anything else should be ignored by backoff.
