### PR TITLE
plan_upgrade and access to account from Tenant

### DIFF
--- a/threescale_api/resources.py
+++ b/threescale_api/resources.py
@@ -1276,6 +1276,18 @@ class Tenant(DefaultResource):
         """
         return self.threescale_client.tenants.trigger_billing_account(self, account, date)
 
+    def plan_upgrade(self, plan_id):
+        """Upgrade plan to given plan_id"""
+        return self.client.rest.put(f"{self.url}/plan_upgrade", params={"plan_id": plan_id})
+
+    @property
+    def account(self):
+        """Return account of this tenant"""
+        return Account(
+            client=self.threescale_client.accounts,
+            entity=self.entity["signup"]["account"]
+        )
+
 
 class Application(DefaultResource):
     def __init__(self, entity_name='name', **kwargs):


### PR DESCRIPTION
Interface for new call plan_upgrade in Tenant.
Interface to get account directly from Tenant, not necessary to search
by name.
